### PR TITLE
Fix duplicate /health endpoint in backend

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -413,7 +413,3 @@ def tts_fx(in_: TtsIn):
     x = bp_filter(x); x = comp_soft(x); x = add_hiss(x); x = np.concatenate([x, squelch_tail()], axis=0)
     wav = to_wav_bytes(x)
     return Response(content=wav, media_type="audio/wav")
-
-@app.get("/health")
-def health():
-    return {"ok": True, "airport": AIRPORT.get("icao", "MRPV")}


### PR DESCRIPTION
## Summary
- remove repeated `/health` route definition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1463c98bc8325b63a2dc5403ca9da