### PR TITLE
Remove outdated TurnOut definition

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -137,15 +137,6 @@ class TurnIn(BaseModel):
     texto_alumno: str
     contexto: Contexto
 
-class TurnOut(BaseModel):
-    intent: str
-    slots: Dict[str, Optional[str]]
-    missing: List[str]
-    feedback_micro: str
-    atc: str
-    fase: str
-    env: Dict[str, Optional[str]]  # añadido: qnh/viento usados
-
 class EnvOut(BaseModel):
     qnh: Optional[str] = None
     viento_dir: Optional[int] = None


### PR DESCRIPTION
## Summary
- drop initial TurnOut class using env dict
- rely on EnvOut-based TurnOut definition

## Testing
- `python -m py_compile BackEnd/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b14666d1648325b5db2831e41d8e9e