### PR TITLE
Add ATC number formatting and TTS preprocessing

### DIFF
--- a/BackEnd/README.md
+++ b/BackEnd/README.md
@@ -1,0 +1,12 @@
+# Backend
+
+## Formateo numérico ATC
+
+La función `format_atc_number` convierte un valor en su fraseo aeronáutico en español.
+
+Reglas principales:
+- **Pistas y QNH:** se pronuncian dígitos individuales. Ej.: `28` → "dos ocho", `3006` → "tres cero cero seis".
+- **Frecuencias:** dígitos separados con la palabra "decimal". Ej.: `118.3` → "uno uno ocho decimal tres".
+- **Altitudes:** miles y cientos en palabras. Ej.: `4700` → "cuatro mil setecientos".
+
+Esta función se usa en `atc_phrase()` y en el endpoint `/tts` para asegurar que Polly pronuncie correctamente los números.

--- a/BackEnd/tests/test_colacion.py
+++ b/BackEnd/tests/test_colacion.py
@@ -69,3 +69,19 @@ def test_turn_solicitar_rodaje_falta_pista(monkeypatch):
     texto = "tobias superficie alfa bravo charlie solicito rodaje"
     out = main.turn(main.TurnIn(texto_alumno=texto, contexto=ctx))
     assert out.missing == ["pista"]
+
+
+def test_format_atc_number_runway():
+    assert main.format_atc_number("28") == "dos ocho"
+
+
+def test_format_atc_number_qnh():
+    assert main.format_atc_number("3006") == "tres cero cero seis"
+
+
+def test_format_atc_number_freq():
+    assert main.format_atc_number("118.3") == "uno uno ocho decimal tres"
+
+
+def test_format_atc_number_altitude():
+    assert main.format_atc_number(4700) == "cuatro mil setecientos"


### PR DESCRIPTION
## Summary
- implement `format_atc_number` for Spanish ATC phraseology
- use formatted numbers in generated ATC phrases and TTS
- document numeric formatting rules

## Testing
- `pytest -q BackEnd/tests/test_colacion.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca9289ec83259c90f637b4c7a42e