### PR TITLE
Simplify interface with central PTT button

### DIFF
--- a/App/test/widget_test.dart
+++ b/App/test/widget_test.dart
@@ -1,30 +1,11 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:ecowhisky_atc/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('renders PTT button and feedback', (WidgetTester tester) async {
+    await tester.pumpWidget(const EcoWhiskyApp());
+    expect(find.byIcon(Icons.mic), findsOneWidget);
+    expect(find.text('Feedback:'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Replace multiple text inputs with a central push-to-talk button that records while pressed
- Show only feedback below the PTT button
- Update widget test to verify presence of PTT button and feedback label

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b21fac238c8325b3b3726476503329